### PR TITLE
Update build system to allow co-existence of multiple binary bindings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ build
 # build script local files
 build/buildinfo.properties
 build/config/buildinfo.properties
+lib/binding

--- a/build-util/tools.js
+++ b/build-util/tools.js
@@ -1,0 +1,88 @@
+var http = require('http');
+var url = require('url');
+
+function download(from,options,callback) {
+    options = options || {};
+    var uri = url.parse(from);
+    var req = http.request(uri);
+    req.on('response', function(res){
+        // needed for end to be called
+        res.resume();
+        if (res.statusCode !== 200) {
+            return callback(new Error('Server returned '+ res.statusCode));
+        }
+        function returnBuffer() {
+            // todo - use http://nodejs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength
+            for (var length = 0, i = 0; i < out.length; ++i) {
+                length += out[i].length;
+            }
+            var result = new Buffer(length);
+            for (var pos = 0, j = 0; j < out.length; ++j) {
+                out[j].copy(result, pos);
+                pos += out[j].length;
+            }
+            return callback(null,result);
+        }
+        var out = [];
+        res.on('data', function(chunk) {
+            out.push(chunk);
+        });
+        res.on('end', function(){
+            returnBuffer();
+        });
+        res.on('close', function(){
+            returnBuffer();
+        });
+    });
+    req.on('error', function(err){
+        callback(err);
+    });
+    req.end();
+}
+
+
+function parse_args(_args, opts) {
+    // first split them like npm returns
+    var args = [], next_arg;
+    _args.forEach(function(a) {
+        var parts = a.split('=');
+        parts.forEach(function(p) {
+            args.push(p);
+        });
+    });
+    // respect flags passed to npm install
+    if (process.env.npm_config_argv) {
+        var argv_obj = JSON.parse(process.env.npm_config_argv);
+        args = args.concat(argv_obj.cooked.slice(1));
+    }
+    var debug = (args.indexOf('--debug') > -1);
+    if (debug) { opts.configuration = 'Debug'; }
+
+    opts.stage = (args.indexOf('--stage') > -1);
+    if (opts.stage) {
+        opts.force = true;
+    } else {
+        var from_source = args.indexOf('--build-from-source');
+        if ( from_source > -1) {
+            // no specific module name passed
+            next_arg = args[from_source+1];
+            if (!next_arg || next_arg.indexOf('--') <= 0) {
+                opts.force = true;
+            } else if (next_arg === 'sqlite3'){
+                opts.force = true;
+            }
+        }
+    }
+    var target_arch = args.indexOf('--target_arch');
+    if (target_arch > -1) {
+        next_arg = args[target_arch+1];
+        if (next_arg && next_arg.indexOf('--') < 0) {
+            opts.target_arch = next_arg;
+        }
+    }
+    opts.args = args;
+    return opts;
+}
+
+module.exports.parse_args = parse_args;
+module.exports.download = download;

--- a/build.js
+++ b/build.js
@@ -1,0 +1,112 @@
+// we borrow some build system tooling from node-sqlite3
+var package_json = require('./package.json');
+var Binary = require('./lib/binary_name.js').Binary;
+var util = require('./build-util/tools.js');
+
+var cp = require('child_process');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
+
+var opts = {
+    name: 'syslog',
+    force: false,
+    stage: false,
+    configuration: 'Release',
+    target_arch: process.arch,
+    platform: process.platform,
+    tool: 'node-gyp',
+    paths: {}
+};
+
+function log(msg) {
+    console.log('['+package_json.name+']: ' + msg);
+}
+
+// only for dev
+function log_debug(msg) {
+    log(msg);
+}
+
+function done(err) {
+    if (err) {
+        log(err);
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+function build(opts,callback) {
+    var shell_cmd = opts.tool;
+    if (opts.tool === 'node-gyp' && process.platform === 'win32') {
+        shell_cmd = 'node-gyp.cmd';
+    }
+    var shell_args = ['rebuild'].concat(opts.args);
+    var cmd = cp.spawn(shell_cmd,shell_args, {cwd: undefined, env: process.env, customFds: [ 0, 1, 2]});
+    cmd.on('error', function (err) {
+        if (err) {
+            return callback(new Error("Failed to execute '" + shell_cmd + ' ' + shell_args.join(' ') + "' (" + err + ")"));
+        }
+    });
+    // exit not close to support node v0.6.x
+    cmd.on('exit', function (code) {
+        if (code !== 0) {
+            return callback(new Error("Failed to execute '" + shell_cmd + ' ' + shell_args.join(' ') + "' (" + code + ")"));
+        }
+        move(opts,callback);
+    });
+}
+
+function move(opts,callback) {
+    try {
+        fs.statSync(opts.paths.build_module_path);
+    } catch (ex) {
+        return callback(new Error('Build succeeded but target not found at ' + opts.paths.build_module_path));
+    }
+    try {
+        mkdirp.sync(path.dirname(opts.paths.runtime_module_path));
+        log('Created: ' + path.dirname(opts.paths.runtime_module_path));
+    } catch (err) {
+        log_debug(err);
+    }
+    fs.renameSync(opts.paths.build_module_path,opts.paths.runtime_module_path);
+    if (opts.stage) {
+        try {
+            mkdirp.sync(path.dirname(opts.paths.staged_module_file_name));
+            log('Created: ' + path.dirname(opts.paths.staged_module_file_name));
+        } catch (err) {
+            log_debug(err);
+        }
+        fs.writeFileSync(opts.paths.staged_module_file_name,fs.readFileSync(opts.paths.runtime_module_path));
+        // drop build metadata into build folder
+        var metapath = path.join(path.dirname(opts.paths.staged_module_file_name),'build-info.json');
+        // more build info
+        opts.date = new Date();
+        opts.node_features = process.features;
+        opts.versions = process.versions;
+        opts.config = process.config;
+        opts.execPath = process.execPath;
+        fs.writeFileSync(metapath,JSON.stringify(opts,null,2));
+        //tarball(opts,callback);
+        return callback();
+    } else {
+        log('Installed in ' + opts.paths.runtime_module_path + '');
+        return callback();
+    }
+}
+
+function rel(p) {
+    return path.relative(process.cwd(),p);
+}
+
+// build it!
+opts = util.parse_args(process.argv.slice(2), opts);
+opts.binary = new Binary(opts);
+var versioned = opts.binary.getRequirePath();
+opts.paths.runtime_module_path = rel(path.join(__dirname, 'lib', versioned));
+opts.paths.runtime_folder = rel(path.join(__dirname, 'lib', 'binding',opts.binary.configuration));
+var staged_module_path = path.join(__dirname, 'stage', opts.binary.getModuleAbi(), opts.binary.getBasePath());
+opts.paths.staged_module_file_name = rel(path.join(staged_module_path,opts.binary.filename()));
+opts.paths.build_module_path = rel(path.join(__dirname, 'build', opts.binary.configuration, opts.binary.filename()));
+
+build(opts, done);

--- a/lib/binary_name.js
+++ b/lib/binary_name.js
@@ -1,0 +1,59 @@
+
+var path = require('path');
+
+var Binary = function(options) {
+  options = options || {};
+  var package_json = options.package_json || require('../package.json');
+  this.name = options.name || 'binding';
+  this.configuration = options.configuration || 'Release';
+  this.uri = options.uri || 'http://'+this.name+'.s3.amazonaws.com/';
+  this.module_maj_min = package_json.version.split('.').slice(0,2).join('.');
+  this.module_abi = package_json.abi;
+  this.platform = options.platform || process.platform;
+  this.target_arch = options.target_arch || process.arch;
+  if (process.versions.modules) {
+    // added in >= v0.10.4 and v0.11.7
+    // https://github.com/joyent/node/commit/ccabd4a6fa8a6eb79d29bc3bbe9fe2b6531c2d8e
+    this.node_abi = 'node-v' + (+process.versions.modules);
+  } else {
+    this.node_abi = 'v8-' + process.versions.v8.split('.').slice(0,2).join('.');
+  }
+};
+
+Binary.prototype.filename = function() {
+    return this.name + '.node';
+};
+
+Binary.prototype.compression = function() {
+    return '.tar.gz';
+};
+
+Binary.prototype.getBasePath = function() {
+    return this.node_abi +
+           '-' + this.platform +
+           '-' + this.target_arch;
+};
+
+Binary.prototype.getRequirePath = function(configuration) {
+    return './' + path.join('binding',
+        configuration || this.configuration,
+        this.getBasePath(),
+        this.filename());
+};
+
+Binary.prototype.getModuleAbi = function() {
+    return this.name + '-v' + this.module_maj_min + '.' + this.module_abi;
+};
+
+Binary.prototype.getArchivePath = function() {
+    return this.getModuleAbi() +
+           '-' +
+           this.getBasePath() +
+           this.compression();
+};
+
+Binary.prototype.getRemotePath = function() {
+    return this.uri+this.configuration+'/'+this.getArchivePath();
+};
+
+module.exports.Binary = Binary;

--- a/lib/rconsole.js
+++ b/lib/rconsole.js
@@ -23,8 +23,16 @@
 
 // RFC -- http://tools.ietf.org/html/rfc5424
 
-var bindings = require('bindings')('syslog')
-  , util = require('util')
+var Binary = require('./binary_name.js').Binary;
+var binary = new Binary({name:'syslog'});
+var bindings;
+try {
+  bindings = require(binary.getRequirePath('Debug'));
+} catch (err) {
+  bindings = require(binary.getRequirePath('Release'));
+}
+
+var util = require('util')
   , stream = require('stream')
   , colors = require('colors')
   , sev = { 

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   },
   "scripts": {
     "test": "make test",
-    "install": "node-gyp rebuild"
+    "install": "node build.js || nodejs build.js"
   },
   "dependencies": {
     "colors": "~0.6.0-1",
-    "bindings": "*"
+    "mkdirp":"~0.3.5"
   },
-  "main": "rconsole.js",
+  "main": "lib/rconsole.js",
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
Borrow some build system infrastructure from node-sqlite3 to allow
the simultaneous installation of bindings for different architectures
(ia32, x64) and node versions (0.8, 0.10, etc).
